### PR TITLE
Fixes broken link to doesNotEqual section of TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Sassaby is a unit testing library for SASS mixins and functions. It is written i
 - [Rules](#rules)
   - [Function Rules](#function-rules)
     - [equals](#equals)
-    - [doesNotEqual](#doesnotaqual)
+    - [doesNotEqual](#doesnotequal)
     - [isTrue](#istrue)
     - [isFalse](#isfalse)
     - [isTruthy](#istruthy)


### PR DESCRIPTION
Changes "doesnotaqual" to "doesnotequal" in the table of contents
